### PR TITLE
add roles and lock non-public routes

### DIFF
--- a/workspaces/backend/src/app.controller.ts
+++ b/workspaces/backend/src/app.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { AuthService } from './auth/auth.service';
+import { Public } from './auth/decorators/public.decorator';
 import { LocalAuthGuard } from './auth/guards/local-auth.guard';
 
 @Controller()
 export class AppController {
   constructor(private authService: AuthService) {}
 
+  @Public()
   @UseGuards(LocalAuthGuard)
   @Post('auth/login')
   async login(@Req() req: Request) {

--- a/workspaces/backend/src/app.module.ts
+++ b/workspaces/backend/src/app.module.ts
@@ -7,6 +7,9 @@ import { CategoriesModule } from './categories/categories.module';
 import { UsersModule } from './users/users.module';
 import { CartsModule } from './carts/carts.module';
 import { AuthModule } from './auth/auth.module';
+import { RolesGuard } from './auth/guards/roles.guard';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -20,5 +23,15 @@ import { AuthModule } from './auth/auth.module';
     AuthModule,
   ],
   controllers: [AppController],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/workspaces/backend/src/auth/auth.service.ts
+++ b/workspaces/backend/src/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
   }
 
   async login(user: any) {
-    const payload = { email: user.email, sub: user._id };
+    const payload = { email: user.email, sub: user._id, role: user.role };
     return {
       access_token: this.jwtService.sign(payload),
     };

--- a/workspaces/backend/src/auth/decorators/public.decorator.ts
+++ b/workspaces/backend/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/workspaces/backend/src/auth/decorators/roles.decorator.ts
+++ b/workspaces/backend/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/workspaces/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/workspaces/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/workspaces/backend/src/auth/guards/roles.guard.ts
+++ b/workspaces/backend/src/auth/guards/roles.guard.ts
@@ -1,0 +1,25 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    if (!user) {
+      return false;
+    }
+    return requiredRoles.some((role) => user.role === role);
+  }
+}

--- a/workspaces/backend/src/auth/role.enum.ts
+++ b/workspaces/backend/src/auth/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  Customer = 'customer',
+  Admin = 'admin',
+}

--- a/workspaces/backend/src/auth/strategies/jwt.strategy.ts
+++ b/workspaces/backend/src/auth/strategies/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    return { userId: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/workspaces/backend/src/products/products.controller.ts
+++ b/workspaces/backend/src/products/products.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { Public } from 'src/auth/decorators/public.decorator';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { ProductsService } from './products.service';
 import { Product } from './schemas/products.schema';
@@ -20,11 +21,13 @@ export class ProductsController {
     return await this.productsServices.create(product);
   }
 
+  @Public()
   @Get()
   async findAll() {
     return await this.productsServices.findAll();
   }
 
+  @Public()
   @Get(':id')
   async findOne(@Param('id') id: string) {
     return await this.productsServices.findOne(id);

--- a/workspaces/backend/src/users/users.controller.ts
+++ b/workspaces/backend/src/users/users.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   Delete,
   UseInterceptors,
-  UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -16,20 +15,19 @@ import MongooseClassSerializerInterceptor from 'src/utils/mongooseClassSerialize
 import { User } from './schemas/user.schema';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { Role } from 'src/auth/role.enum';
-import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
-import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Public } from 'src/auth/decorators/public.decorator';
 
 @Controller('users')
 @UseInterceptors(MongooseClassSerializerInterceptor(User))
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
+  @Public()
   @Post()
   async create(@Body() createUserDto: CreateUserDto) {
     return await this.usersService.create(createUserDto);
   }
 
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.Admin)
   @Get()
   async findAll() {

--- a/workspaces/backend/src/users/users.controller.ts
+++ b/workspaces/backend/src/users/users.controller.ts
@@ -7,12 +7,17 @@ import {
   Param,
   Delete,
   UseInterceptors,
+  UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import MongooseClassSerializerInterceptor from 'src/utils/mongooseClassSerializer.interceptor';
 import { User } from './schemas/user.schema';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { Role } from 'src/auth/role.enum';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
 
 @Controller('users')
 @UseInterceptors(MongooseClassSerializerInterceptor(User))
@@ -24,6 +29,8 @@ export class UsersController {
     return await this.usersService.create(createUserDto);
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Admin)
   @Get()
   async findAll() {
     return await this.usersService.findAll();


### PR DESCRIPTION
Adds basic roles:
- `RoleGuard` is used globally.
- Routes can be marked with the required role using `@Role(role: string)`.

Locks the api:
- `JwtAuthGuard` is used globally.
- A route can be made public using the `@Public()` decorator.

