### PR TITLE
Preserve scroll

### DIFF
--- a/workspaces/frontend/components/ProductDetailsPage.tsx
+++ b/workspaces/frontend/components/ProductDetailsPage.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const ProductDetailsPage = ({ id }: Props) => {
   const { product, isFetched } = useProduct(id);
-  console.log(product);
+
   if (!isFetched || !product) {
     return null;
   }

--- a/workspaces/frontend/pages/_app.tsx
+++ b/workspaces/frontend/pages/_app.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ReactElement, ReactNode } from "react";
 import { NextPage } from "next";
+import { usePreserveScroll } from "../utils/hooks/usePreserveScroll";
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -17,6 +18,7 @@ const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);
+  usePreserveScroll();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/workspaces/frontend/pages/products/new-product.tsx
+++ b/workspaces/frontend/pages/products/new-product.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import React, { useRef, useState } from "react";
+import React, { ReactElement, useRef, useState } from "react";
 import Button from "../../components/Button";
 import Header from "../../components/Header";
 import TextareaAutosize from "react-textarea-autosize";
@@ -9,6 +9,7 @@ import { useUploads } from "../../utils/hooks/useUploads";
 import Image from "next/image";
 import useProducts from "../../utils/hooks/useProducts";
 import toast from "react-hot-toast";
+import BaseLayout from "../../components/BaseLayout";
 
 interface Values {
   name: string;
@@ -68,7 +69,6 @@ const NewProduct = () => {
         <title>Admin - New Product</title>
         <link rel="icon" href="/WebShopLogo.png"></link>
       </Head>
-      <Header />
       <Formik
         initialValues={{
           name: "",
@@ -86,7 +86,7 @@ const NewProduct = () => {
           createProduct.mutate(payload, {
             onSuccess: () => {
               toast.success(`Product, ${values.name}, added!`, {
-                position: "bottom-center",
+                position: "top-center",
                 className: "text-sm",
               });
               setSubmitting(false);
@@ -242,5 +242,7 @@ const NewProduct = () => {
     </>
   );
 };
+
+NewProduct.getLayout = (page: ReactElement) => <BaseLayout>{page}</BaseLayout>;
 
 export default NewProduct;

--- a/workspaces/frontend/utils/hooks/usePreserveScroll.ts
+++ b/workspaces/frontend/utils/hooks/usePreserveScroll.ts
@@ -1,0 +1,43 @@
+import { useRouter } from "next/router";
+import { useEffect, useRef } from "react";
+
+// Kindly borrowed (and slightly modified) from
+// https://jak-ch-ll.medium.com/next-js-preserve-scroll-history-334cf699802a
+
+export const usePreserveScroll = () => {
+  const router = useRouter();
+
+  const scrollPositions = useRef<{ [url: string]: number }>({});
+  const isBack = useRef(false);
+
+  useEffect(() => {
+    router.beforePopState(() => {
+      isBack.current = true;
+      return true;
+    });
+
+    const onRouteChangeStart = () => {
+      const url = router.asPath;
+      scrollPositions.current[url] = window.scrollY;
+    };
+
+    const onRouteChangeComplete = (url: string) => {
+      if (isBack.current && scrollPositions.current[url]) {
+        window.scroll({
+          top: scrollPositions.current[url],
+          behavior: "auto",
+        });
+      }
+
+      isBack.current = false;
+    };
+
+    router.events.on("routeChangeStart", onRouteChangeStart);
+    router.events.on("routeChangeComplete", onRouteChangeComplete);
+
+    return () => {
+      router.events.off("routeChangeStart", onRouteChangeStart);
+      router.events.off("routeChangeComplete", onRouteChangeComplete);
+    };
+  }, [router]);
+};


### PR DESCRIPTION
Scroll on previous pages is stored when going back. For example, on the category page, when navigating to the details page of a product and then going back, scrolling is restored to where it was so that you don't have to scroll down to view the category's products again.

Kindly stolen from here:
https://jak-ch-ll.medium.com/next-js-preserve-scroll-history-334cf699802a